### PR TITLE
#8 Specify time zone to use in DateAndTimeDummyTest instead of using …

### DIFF
--- a/src/test/java/dev/codesoapbox/dummy4j/dummies/DateAndTimeDummyTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/dummies/DateAndTimeDummyTest.java
@@ -21,8 +21,7 @@ class DateAndTimeDummyTest {
 
     private final static LocalDate LOCAL_DATE = LocalDate.of(2000, Month.JANUARY, 1);
 
-    private final Clock clock = Clock.fixed(LOCAL_DATE.atStartOfDay(ZoneId.systemDefault()).toInstant(),
-            ZoneId.systemDefault());
+    private final Clock clock = Clock.fixed(LOCAL_DATE.atStartOfDay(ZoneId.of("GMT")).toInstant(), ZoneId.of("GMT"));
 
     private DateAndTimeDummy dateAndTimeDummy;
 


### PR DESCRIPTION
…the default value.

Fixes #8 