### PR TITLE
Add JAVA_HOME location to maven-javadoc-plugin configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.1</version>
+                <configuration>
+                    <!-- https://stackoverflow.com/a/49477048/7995881 -->
+                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>


### PR DESCRIPTION
Solution from [this StackOverflow question](https://stackoverflow.com/a/49477048/7995881)

Error for command
```bash
$ mvn verify sonar:sonar
```
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:jar (attach-javadoc) on project dummy4j: MavenReportException:
Error while generating Javadoc: Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set.

For more information read the following articles: http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

```

My environment details:
``` bash
$ javac --version
javac 11.0.8
```
```bash
$ mvn --version
Apache Maven 3.6.0
Maven home: /usr/share/maven
Java version: 11.0.8, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64
```
```bash
$ which java
/usr/bin/java
```
```bash
$ dirname $(dirname $(readlink -f $(which javac)))
/usr/lib/jvm/java-11-openjdk-amd64
```
Empty result for:
```bash
$ echo $JAVA_HOME
```