### PR TITLE
Check for empty or null collections in convenience methods

### DIFF
--- a/src/main/java/dev/codesoapbox/dummy4j/ConvenienceMethods.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ConvenienceMethods.java
@@ -53,11 +53,16 @@ public class ConvenienceMethods {
      * Returns a random element from an array
      *
      * @param array the array to pick from
-     * @param <T> the type of object to return
+     * @param <T>   the type of object to return
      * @return a random element
      */
     @SafeVarargs
     public final <T> T of(T... array) {
+        if (array.length == 0) {
+            return null;
+        } else if (array.length == 1) {
+            return array[0];
+        }
         return array[random.nextInt(array.length - 1)];
     }
 
@@ -65,10 +70,15 @@ public class ConvenienceMethods {
      * Returns a random element from a list
      *
      * @param list the list to pick from
-     * @param <T> the type of object to return
+     * @param <T>  the type of object to return
      * @return a random element
      */
     public <T> T of(List<T> list) {
+        if (list == null || list.isEmpty()) {
+            return null;
+        } else if (list.size() == 1) {
+            return list.get(0);
+        }
         return list.get(random.nextInt(list.size() - 1));
     }
 
@@ -81,6 +91,11 @@ public class ConvenienceMethods {
      */
     @SuppressWarnings("unchecked")
     public <T> T of(Set<T> set) {
+        if (set == null || set.isEmpty()) {
+            return null;
+        } else if (set.size() == 1) {
+            return (T) set.toArray()[0];
+        }
         return (T) set.toArray()[random.nextInt(set.size() - 1)];
     }
 
@@ -88,11 +103,16 @@ public class ConvenienceMethods {
      * Returns a value from a random supplier.
      *
      * @param suppliers value suppliers to pick from
-     * @param <T> the type of value to return
+     * @param <T>       the type of value to return
      * @return a value from a random supplier
      */
     @SafeVarargs
     public final <T> T of(Supplier<T>... suppliers) {
+        if (suppliers == null || suppliers.length == 0) {
+            return null;
+        } else if (suppliers.length == 1) {
+            return suppliers[0].get();
+        }
         return suppliers[random.nextInt(0, suppliers.length - 1)].get();
     }
 
@@ -103,7 +123,6 @@ public class ConvenienceMethods {
      * 50% of the time when the method is invoked.
      *
      * @return supplied {@code T} or null
-     *
      * @since 0.5.0
      */
     public <T> T chance(int howMany, int in, Supplier<T> supplier) {
@@ -121,7 +140,6 @@ public class ConvenienceMethods {
      * 50% of the time when the method is invoked.
      *
      * @return {@code boolean}
-     *
      * @since 0.5.0
      */
     public boolean chance(int howMany, int in) {

--- a/src/main/java/dev/codesoapbox/dummy4j/ConvenienceMethods.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ConvenienceMethods.java
@@ -54,7 +54,7 @@ public class ConvenienceMethods {
      *
      * @param array the array to pick from
      * @param <T>   the type of object to return
-     * @return a random element
+     * @return a random element from the array or NULL if the array is empty
      */
     @SafeVarargs
     public final <T> T of(T... array) {
@@ -71,7 +71,7 @@ public class ConvenienceMethods {
      *
      * @param list the list to pick from
      * @param <T>  the type of object to return
-     * @return a random element
+     * @return a random element from the list or NULL if the list is NULL or empty
      */
     public <T> T of(List<T> list) {
         if (list == null || list.isEmpty()) {
@@ -87,7 +87,7 @@ public class ConvenienceMethods {
      *
      * @param set the list to pick from
      * @param <T> the type of object to return
-     * @return a random element
+     * @return a random element from the set or NULL if the set is NULL or empty
      */
     @SuppressWarnings("unchecked")
     public <T> T of(Set<T> set) {
@@ -104,7 +104,7 @@ public class ConvenienceMethods {
      *
      * @param suppliers value suppliers to pick from
      * @param <T>       the type of value to return
-     * @return a value from a random supplier
+     * @return a value from a random supplier or NULL if an empty array or NULL was given as an argument
      */
     @SafeVarargs
     public final <T> T of(Supplier<T>... suppliers) {

--- a/src/main/java/dev/codesoapbox/dummy4j/ConvenienceMethods.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ConvenienceMethods.java
@@ -113,7 +113,7 @@ public class ConvenienceMethods {
         } else if (suppliers.length == 1) {
             return suppliers[0].get();
         }
-        return suppliers[random.nextInt(0, suppliers.length - 1)].get();
+        return suppliers[random.nextInt(suppliers.length - 1)].get();
     }
 
     /**

--- a/src/main/java/dev/codesoapbox/dummy4j/dummies/finance/IbanBuilder.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/dummies/finance/IbanBuilder.java
@@ -3,6 +3,7 @@ package dev.codesoapbox.dummy4j.dummies.finance;
 import dev.codesoapbox.dummy4j.Dummy4j;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
@@ -79,23 +80,13 @@ public class IbanBuilder {
      * Generates a random IBAN
      */
     public String build() {
-        BankAccountCountry country = getCountry();
+        BankAccountCountry country = Optional.ofNullable(dummy4j.of(countries))
+                .orElse(dummy4j.nextEnum(BankAccountCountry.class));
         String account = dummy4j.finance().bankAccountNumber(country);
         String countryCode = country.getCode();
         String iban = countryCode + ibanFormula.getCheckDigits(account, countryCode) + account;
 
         return format(iban);
-    }
-
-    private BankAccountCountry getCountry() {
-        if (countries.isEmpty()) {
-            return dummy4j.nextEnum(BankAccountCountry.class);
-        } else if (countries.size() == 1) {
-            return countries.get(0);
-        } else {
-            int randomIndex = dummy4j.number().nextInt(countries.size() - 1);
-            return countries.get(randomIndex);
-        }
     }
 
     private String format(String iban) {

--- a/src/main/java/dev/codesoapbox/dummy4j/dummies/internet/UrlBuilder.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/dummies/internet/UrlBuilder.java
@@ -7,6 +7,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 import static java.util.Collections.singletonList;
@@ -208,7 +209,8 @@ public final class UrlBuilder {
      * @see URL
      */
     public URL build() {
-        UrlProtocol protocol = getProtocol();
+        UrlProtocol protocol = Optional.ofNullable(dummy4j.of(possibleProtocols))
+                .orElse(dummy4j.nextEnum(UrlProtocol.class));
         UrlHost host = getUrlHost();
         String filePathAndQueryParams = getFilePath();
 
@@ -217,17 +219,6 @@ public final class UrlBuilder {
         }
 
         return buildUrlWithProperLength(protocol, host, filePathAndQueryParams);
-    }
-
-    private UrlProtocol getProtocol() {
-        if (possibleProtocols.isEmpty()) {
-            return dummy4j.nextEnum(UrlProtocol.class);
-        } else if (possibleProtocols.size() == 1) {
-            return possibleProtocols.get(0);
-        } else {
-            int randomIndex = dummy4j.number().nextInt(possibleProtocols.size() - 1);
-            return possibleProtocols.get(randomIndex);
-        }
     }
 
     private UrlHost getUrlHost() {

--- a/src/test/java/dev/codesoapbox/dummy4j/ConvenienceMethodsTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/ConvenienceMethodsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -80,7 +81,7 @@ class ConvenienceMethodsTest {
         String[] array = {};
 
         assertNull(convenienceMethods.of(array));
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @Test
@@ -106,13 +107,13 @@ class ConvenienceMethodsTest {
         List<String> list = emptyList();
 
         assertNull(convenienceMethods.of(list));
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @Test
     void shouldReturnNullIfListIsNull() {
         assertNull(convenienceMethods.of((List<?>) null));
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @Test
@@ -138,13 +139,13 @@ class ConvenienceMethodsTest {
         Set<String> set = emptySet();
 
         assertNull(convenienceMethods.of(set));
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @Test
     void shouldReturnNullIfSetIsNull() {
         assertNull(convenienceMethods.of((Set<?>) null));
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @Test
@@ -173,7 +174,7 @@ class ConvenienceMethodsTest {
         Object result = convenienceMethods.of(suppliersArray);
 
         assertNull(result);
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt(), Mockito.anyInt());
     }
 
     @Test
@@ -181,13 +182,13 @@ class ConvenienceMethodsTest {
         Supplier<Object>[] suppliersArray = null;
 
         assertNull(convenienceMethods.of(suppliersArray));
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt(), Mockito.anyInt());
     }
 
     @Test
     void shouldReturnNullIfSupplierArrayMissing() {
         assertNull(convenienceMethods.of());
-        verify(random, never()).nextInt(0);
+        verify(random, never()).nextInt(Mockito.anyInt(), Mockito.anyInt());
     }
 
     @ParameterizedTest

--- a/src/test/java/dev/codesoapbox/dummy4j/ConvenienceMethodsTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/ConvenienceMethodsTest.java
@@ -150,7 +150,7 @@ class ConvenienceMethodsTest {
 
     @Test
     void shouldSupplyFromRandomSupplier() {
-        when(random.nextInt(0, 2))
+        when(random.nextInt(2))
                 .thenReturn(1);
 
         int result = convenienceMethods.of(() -> 1, () -> 2, () -> 3);
@@ -174,7 +174,7 @@ class ConvenienceMethodsTest {
         Object result = convenienceMethods.of(suppliersArray);
 
         assertNull(result);
-        verify(random, never()).nextInt(Mockito.anyInt(), Mockito.anyInt());
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @Test
@@ -182,13 +182,13 @@ class ConvenienceMethodsTest {
         Supplier<Object>[] suppliersArray = null;
 
         assertNull(convenienceMethods.of(suppliersArray));
-        verify(random, never()).nextInt(Mockito.anyInt(), Mockito.anyInt());
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @Test
     void shouldReturnNullIfSupplierArrayMissing() {
         assertNull(convenienceMethods.of());
-        verify(random, never()).nextInt(Mockito.anyInt(), Mockito.anyInt());
+        verify(random, never()).nextInt(Mockito.anyInt());
     }
 
     @ParameterizedTest

--- a/src/test/java/dev/codesoapbox/dummy4j/ConvenienceMethodsTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/ConvenienceMethodsTest.java
@@ -13,10 +13,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ConvenienceMethodsTest {
@@ -56,12 +59,28 @@ class ConvenienceMethodsTest {
 
     @Test
     void shouldReturnRandomElementFromArray() {
-        String[] array = { "one", "two", "three" };
+        String[] array = {"one", "two", "three"};
 
         when(random.nextInt(2))
                 .thenReturn(2);
 
         assertEquals("three", convenienceMethods.of(array));
+    }
+
+    @Test
+    void shouldReturnFirstElementFromOneElementArray() {
+        String[] array = {"one"};
+
+        assertEquals("one", convenienceMethods.of(array));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
+    void shouldReturnNullForEmptyArray() {
+        String[] array = {};
+
+        assertNull(convenienceMethods.of(array));
+        verify(random, never()).nextInt(0);
     }
 
     @Test
@@ -75,6 +94,28 @@ class ConvenienceMethodsTest {
     }
 
     @Test
+    void shouldReturnFirstElementFromOneElementList() {
+        List<String> list = singletonList("one");
+
+        assertEquals("one", convenienceMethods.of(list));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
+    void shouldReturnNullForEmptyList() {
+        List<String> list = emptyList();
+
+        assertNull(convenienceMethods.of(list));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
+    void shouldReturnNullIfListIsNull() {
+        assertNull(convenienceMethods.of((List<?>) null));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
     void shouldReturnRandomElementFromSet() {
         Set<String> set = new HashSet<>(asList("one", "two", "three"));
 
@@ -85,6 +126,28 @@ class ConvenienceMethodsTest {
     }
 
     @Test
+    void shouldReturnFirstElementFromOneElementSet() {
+        Set<String> set = new HashSet<>(singletonList("one"));
+
+        assertEquals("one", convenienceMethods.of(set));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
+    void shouldReturnNullForEmptySet() {
+        Set<String> set = emptySet();
+
+        assertNull(convenienceMethods.of(set));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
+    void shouldReturnNullIfSetIsNull() {
+        assertNull(convenienceMethods.of((Set<?>) null));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
     void shouldSupplyFromRandomSupplier() {
         when(random.nextInt(0, 2))
                 .thenReturn(1);
@@ -92,6 +155,39 @@ class ConvenienceMethodsTest {
         int result = convenienceMethods.of(() -> 1, () -> 2, () -> 3);
 
         assertEquals(2, result);
+    }
+
+    @Test
+    void shouldReturnFirstElementFromOneElementSupplierArray() {
+        int result = convenienceMethods.of(() -> 1);
+
+        assertEquals(1, result);
+        verify(random, never()).nextInt(0, 0);
+    }
+
+    @Test
+    void shouldReturnNullForEmptySupplierArray() {
+        @SuppressWarnings("unchecked")
+        Supplier<Object>[] suppliersArray = new Supplier[]{};
+
+        Object result = convenienceMethods.of(suppliersArray);
+
+        assertNull(result);
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
+    void shouldReturnNullIfSupplierArrayIsNull() {
+        Supplier<Object>[] suppliersArray = null;
+
+        assertNull(convenienceMethods.of(suppliersArray));
+        verify(random, never()).nextInt(0);
+    }
+
+    @Test
+    void shouldReturnNullIfSupplierArrayMissing() {
+        assertNull(convenienceMethods.of());
+        verify(random, never()).nextInt(0);
     }
 
     @ParameterizedTest

--- a/src/test/java/dev/codesoapbox/dummy4j/dummies/finance/IbanBuilderTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/dummies/finance/IbanBuilderTest.java
@@ -1,7 +1,6 @@
 package dev.codesoapbox.dummy4j.dummies.finance;
 
 import dev.codesoapbox.dummy4j.Dummy4j;
-import dev.codesoapbox.dummy4j.NumberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +9,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -24,9 +26,6 @@ class IbanBuilderTest {
 
     @Mock
     private IbanFormula ibanFormula;
-
-    @Mock
-    private NumberService numberService;
 
     private IbanBuilder builder;
 
@@ -86,6 +85,8 @@ class IbanBuilderTest {
         String accountNumber = mockAccountNumber(country);
         when(ibanFormula.getCheckDigits(accountNumber, country.getCode()))
                 .thenReturn("51");
+        when(dummy4j.of(singletonList(country)))
+                .thenReturn(country);
 
         String actual = builder
                 .withCountry(country)
@@ -97,24 +98,18 @@ class IbanBuilderTest {
     @Test
     void shouldBuildIbanForGivenCountries() {
         mockFinanceDummy();
-        mockNumberService();
-        when(numberService.nextInt(1))
-                .thenReturn(0);
         BankAccountCountry albania = BankAccountCountry.ALBANIA;
         String accountNumber = mockAccountNumber(albania);
         when(ibanFormula.getCheckDigits(accountNumber, albania.getCode()))
                 .thenReturn("57");
+        when(dummy4j.of(Arrays.asList(albania, BankAccountCountry.MACEDONIA)))
+                .thenReturn(albania);
 
         String actual = builder
                 .withRandomCountry(albania, BankAccountCountry.MACEDONIA)
                 .build();
 
         assertEquals("AL5712345678901", actual);
-    }
-
-    private void mockNumberService() {
-        when(dummy4j.number())
-                .thenReturn(numberService);
     }
 
     @Test
@@ -124,6 +119,8 @@ class IbanBuilderTest {
         String accountNumber = mockAccountNumber(germany);
         when(ibanFormula.getCheckDigits(accountNumber, germany.getCode()))
                 .thenReturn("51");
+        when(dummy4j.of(singletonList(germany)))
+                .thenReturn(germany);
 
         String actual = builder
                 .withRandomCountry(BankAccountCountry.ALBANIA, BankAccountCountry.MACEDONIA)
@@ -165,6 +162,8 @@ class IbanBuilderTest {
         String accountNumber = mockAccountNumber(country);
         when(ibanFormula.getCheckDigits(accountNumber, country.getCode()))
                 .thenReturn("51");
+        when(dummy4j.of(singletonList(country)))
+                .thenReturn(country);
 
         String actual = builder
                 .withCountry(country)

--- a/src/test/java/dev/codesoapbox/dummy4j/dummies/finance/IbanBuilderTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/dummies/finance/IbanBuilderTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
-
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -102,7 +101,7 @@ class IbanBuilderTest {
         String accountNumber = mockAccountNumber(albania);
         when(ibanFormula.getCheckDigits(accountNumber, albania.getCode()))
                 .thenReturn("57");
-        when(dummy4j.of(Arrays.asList(albania, BankAccountCountry.MACEDONIA)))
+        when(dummy4j.of(asList(albania, BankAccountCountry.MACEDONIA)))
                 .thenReturn(albania);
 
         String actual = builder

--- a/src/test/java/dev/codesoapbox/dummy4j/dummies/internet/InternetDummyTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/dummies/internet/InternetDummyTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URL;
 
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +45,8 @@ class InternetDummyTest {
     @Test
     void shouldReturnDefaultUrl() {
         mockSimpleUrl();
+        when(dummy4j.of(singletonList(UrlProtocol.HTTPS)))
+                .thenReturn(UrlProtocol.HTTPS);
 
         URL actual = internetDummy.url();
 
@@ -53,6 +56,8 @@ class InternetDummyTest {
     @Test
     void shouldBuildSimpleUrl() {
         mockSimpleUrl();
+        when(dummy4j.of(singletonList(UrlProtocol.HTTPS)))
+                .thenReturn(UrlProtocol.HTTPS);
 
         URL actual = internetDummy.urlBuilder().build();
 

--- a/src/test/java/dev/codesoapbox/dummy4j/dummies/internet/UrlBuilderTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/dummies/internet/UrlBuilderTest.java
@@ -12,7 +12,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +47,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnSimpleUrl() {
         mockDomain();
+        mockDefaultProtocol();
 
         URL actual = builder.build();
 
@@ -57,6 +61,12 @@ class UrlBuilderTest {
                 () -> assertTrue(actual.getPath().isEmpty()),
                 () -> assertNotNull(actual.toURI())
         );
+    }
+
+    private void mockDefaultProtocol() {
+        List<UrlProtocol> possibleProtocols = singletonList(UrlProtocol.HTTPS);
+        when(dummy4j.of(possibleProtocols))
+                .thenReturn(UrlProtocol.HTTPS);
     }
 
     private void mockDomain() {
@@ -80,6 +90,7 @@ class UrlBuilderTest {
     @Test
     void shouldNotAddExtraCharsWhenMinLengthSatisfied() {
         mockDomain();
+        mockDefaultProtocol();
         int minLength = 20;
 
         URL actual = builder
@@ -93,6 +104,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithoutHostPrefix() {
         mockDomain();
+        mockDefaultProtocol();
 
         URL actual = builder
                 .withoutWwwPrefix()
@@ -107,6 +119,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithGivenPort() {
         mockDomain();
+        mockDefaultProtocol();
 
         URL actual = builder
                 .withPort(12)
@@ -121,6 +134,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithRandomPort() {
         mockDomain();
+        mockDefaultProtocol();
         mockNumberService();
         when(numberService.nextInt(UrlBuilder.MIN_PORT, UrlBuilder.MAX_PORT))
                 .thenReturn(9999);
@@ -143,6 +157,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithFile() {
         mockDomain();
+        mockDefaultProtocol();
         mockLoremDummy();
         when(loremDummy.characters(10))
                 .thenReturn(FILENAME);
@@ -161,6 +176,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithFileAndMinLength() {
         mockDomain();
+        mockDefaultProtocol();
         mockLoremDummy();
         when(loremDummy.characters(6))
                 .thenReturn("aaaaaa");
@@ -184,6 +200,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithWordsInQueryParam() {
         mockDomain();
+        mockDefaultProtocol();
         mockQueryParam();
         mockQueryParamStringValue();
         when(dummy4j.chance(UrlBuilder.CHANCE_OF_PARAM_VALUE_AS_STRING, UrlBuilder.CHANCE_IN_PARAM_VALUE_AS_STRING))
@@ -204,6 +221,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithDigitsInQueryParam() {
         mockDomain();
+        mockDefaultProtocol();
         mockQueryParam();
         mockQueryParamDigitValue();
 
@@ -238,6 +256,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithMultipleQueryParams() {
         mockDomain();
+        mockDefaultProtocol();
         mockQueryParam();
         mockQueryParamStringValue();
         when(dummy4j.chance(UrlBuilder.CHANCE_OF_PARAM_VALUE_AS_STRING, UrlBuilder.CHANCE_IN_PARAM_VALUE_AS_STRING))
@@ -256,6 +275,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithQueryParamAndMinLength() {
         mockDomain();
+        mockDefaultProtocol();
         mockQueryParam();
         mockQueryParamStringValue();
         mockLoremDummy();
@@ -280,6 +300,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithMultipleQueryParamsAndFile() {
         mockDomain();
+        mockDefaultProtocol();
         mockQueryParam();
         mockQueryParamStringValue();
         mockLoremDummy();
@@ -335,6 +356,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithSpecifiedProtocol() {
         mockDomain();
+        mockDefaultProtocol();
 
         URL actual = builder
                 .withProtocol(UrlProtocol.HTTPS)
@@ -349,6 +371,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithSpecifiedProtocolAndMinimumLength() {
         mockDomain();
+        mockDefaultProtocol();
         mockLoremDummy();
         when(loremDummy.characters(2))
                 .thenReturn("aa");
@@ -370,6 +393,7 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithSpecifiedProtocolWithoutWwwPrefixWithWithRandomPortQueryParamsAndFileAndMinLength() {
         mockDomain();
+        mockDefaultProtocol();
         mockQueryParam();
         mockQueryParamStringValue();
         mockNumberService();
@@ -407,6 +431,7 @@ class UrlBuilderTest {
     @Test
     void shouldThrowExceptionOnInvalidUrl() {
         mockDomain();
+        mockDefaultProtocol();
 
         UrlBuilder actual = builder
                 .withPort(-2);
@@ -418,6 +443,8 @@ class UrlBuilderTest {
     void shouldReturnUrlForAllProtocolTypes() {
         mockDomain();
         for (UrlProtocol protocol : UrlProtocol.values()) {
+            when(dummy4j.of(singletonList(protocol)))
+                    .thenReturn(protocol);
             URL url = builder.withProtocol(protocol).build();
 
             assertEquals(protocol.getValue(), url.getProtocol());
@@ -438,9 +465,9 @@ class UrlBuilderTest {
     @Test
     void shouldReturnUrlWithRandomProtocolChosenFromGivenList() {
         mockDomain();
-        mockNumberService();
-        when(dummy4j.number().nextInt(1))
-                .thenReturn(1);
+        List<UrlProtocol> possibleProtocols = Arrays.asList(UrlProtocol.HTTPS, UrlProtocol.FTP);
+        when(dummy4j.of(possibleProtocols))
+                .thenReturn(UrlProtocol.FTP);
 
         URL actual = builder.withRandomProtocol(UrlProtocol.HTTPS, UrlProtocol.FTP).build();
 
@@ -449,6 +476,7 @@ class UrlBuilderTest {
 
     @Test
     void shouldReturnUrlWithPopularDomain() {
+        mockDefaultProtocol();
         mockExpressionResolver();
         when(expressionResolver.resolve(UrlBuilder.ROOT_DOMAIN_KEY))
                 .thenReturn("test");
@@ -462,6 +490,7 @@ class UrlBuilderTest {
 
     @Test
     void shouldReturnUrlWithCountryDomain() {
+        mockDefaultProtocol();
         mockExpressionResolver();
         when(expressionResolver.resolve(UrlBuilder.ROOT_DOMAIN_KEY))
                 .thenReturn("test");
@@ -475,6 +504,7 @@ class UrlBuilderTest {
 
     @Test
     void shouldReturnUrlWithGenericDomain() {
+        mockDefaultProtocol();
         mockExpressionResolver();
         when(expressionResolver.resolve(UrlBuilder.ROOT_DOMAIN_KEY))
                 .thenReturn("test");
@@ -489,6 +519,7 @@ class UrlBuilderTest {
     @Test
     void shouldNotAddQueryParamsWhenRequiredAmountIsZero() {
         mockDomain();
+        mockDefaultProtocol();
 
         URL actual = builder.withQueryParams(0).build();
 
@@ -501,6 +532,7 @@ class UrlBuilderTest {
     @Test
     void shouldNotAddQueryParamsWhenLatestRequiredAmountIsZero() {
         mockDomain();
+        mockDefaultProtocol();
 
         URL actual = builder.withQueryParams(2)
                 .withQueryParams(0)
@@ -516,6 +548,7 @@ class UrlBuilderTest {
 
     @Test
     void shouldReturnUrlWithCustomTopLevelDomain() {
+        mockDefaultProtocol();
         mockExpressionResolver();
         when(expressionResolver.resolve(UrlBuilder.ROOT_DOMAIN_KEY))
                 .thenReturn("test");


### PR DESCRIPTION
* Check if an empty collection, array or null was passed to the ConvenienceMethods::of() methods. Return null in that case. 
* Check if there is only one element to choose from. Return it without generating a random index from a collection/array, it will always be '0'.
* Use ConvenienceMethods::of() in dummies.
* Format code with default IntellilJ format settings.