### PR TITLE
Use Unicode properties when creating the pattern for whitespaces

### DIFF
--- a/src/main/java/dev/codesoapbox/dummy4j/dummies/finance/CreditCardNumberBuilder.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/dummies/finance/CreditCardNumberBuilder.java
@@ -20,7 +20,14 @@ public class CreditCardNumberBuilder {
 
     static final String PARTIAL_CREDIT_CARD_KEY = "#{finance.credit_card_without_check_digit.";
     static final Pattern SANITIZE_NUMBER_PATTERN = Pattern.compile("[^\\d]");
-    static final Pattern SANITIZE_DEFINITION_KEY_PATTERN = Pattern.compile("\\s");
+
+    /**
+     * The pattern uses Unicode properties to cover more cases.
+     *
+     * @see <a href="https://stackoverflow.com/questions/56653323/s-doesnt-actually-capture-all-whitespace-characters/
+     * 56654027#56654027">Capture all whitespace characters (StackOverflow)</a>
+     */
+    static final Pattern SANITIZE_DEFINITION_KEY_PATTERN = Pattern.compile("\\s", Pattern.UNICODE_CHARACTER_CLASS);
 
     private final Dummy4j dummy4j;
     private final LuhnFormula luhnFormula;

--- a/src/main/java/dev/codesoapbox/dummy4j/dummies/internet/StringSanitizer.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/dummies/internet/StringSanitizer.java
@@ -11,9 +11,15 @@ import java.util.regex.Pattern;
 final class StringSanitizer {
 
     /**
-     * Pattern that matches non ASCII characters, whitespaces, backslashes and quotes
+     * Pattern that matches non ASCII characters, whitespaces, backslashes and quotes.
+     * <p>
+     * The pattern uses Unicode properties to cover more cases.
+     *
+     * @see <a href="https://stackoverflow.com/questions/56653323/s-doesnt-actually-capture-all-whitespace-characters/
+     * 56654027#56654027">Capture all whitespace characters (StackOverflow)</a>
      */
-    public static final Pattern SANITIZE_EMAIL_PATTERN = Pattern.compile("[^\\p{ASCII}]+|[\\s\\\\\"]+");
+    public static final Pattern SANITIZE_EMAIL_PATTERN = Pattern.compile("[^\\p{ASCII}]+|[\\s\\\\\"]+",
+            Pattern.UNICODE_CHARACTER_CLASS);
 
     private StringSanitizer() {
     }


### PR DESCRIPTION
By default, \s only matches some ASCII whitespace characters. Make the predefined character class use Unicode properties to cover more cases.