### PR TITLE
Multi-locale placeholders, resolving to keys, nested placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ dummy.unique().within(() -> dummy.name().fullName(), name -> {
 
 List<String> tenLocallyUniqueNames = dummy.unique().of(() -> dummy.name().fullName(), 
                 name -> dummy.listOf(10, name));
+
+// This resolves an expression, finding the appropriate values in yml files.
+// Normally, this should be hidden away under a custom method (e.g. customDummy.maleAndFemaleNames()).
+String resolvedExpression = dummy4j.expressionResolver().resolve("#{name.male_first_name}, #{name.female_first_name}");
 ```
 
 ## Goals and contributing

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -42,13 +42,15 @@ If you choose to, you can place all of your definitions in one file. You can als
 ## Parser
 
 The parser recognizes three placeholders:
-* `#{key.path}` - will resolve to a random value from the list of data definitions using the provided key path; The
- resolved value may itself be an expression. If the path resolves to a list of keys (instead of values),
- a random one of them will be returned. 
- The value will always be taken from a single locale (the first one which contains values for the path).
-* `#{{key.path}}` (since SNAPSHOT) - like above, but will return a random value from the superset of all locales' 
- values.
-* `#` - will resolve to a random digit between 0 and 9 
+* `#{key.path}` (single-locale placeholder) - will resolve to a random value from the list of data definitions using
+ the provided key path; The resolved value may itself be an expression. If the path resolves to a list of keys
+ (instead of values), a random one of them will be returned.
+ The value will always be taken from a single locale (the first one which contains values for the path, unless the
+ placeholder is part of a nested expression in which case it will always resolve only to its parent expression's 
+ locale).
+* `#{{key.path}}` (multi-locale placeholder, since SNAPSHOT) - like above, but will return a random value from the
+  superset of all locales' values, regardless of whether it is part of a nested expression.
+* `#` (number) - will resolve to a random digit between 0 and 9
 
 Dummy4j can resolve expressions, which are a mix of the aforementioned placeholders and other characters, e.g.:
 

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -41,14 +41,16 @@ If you choose to, you can place all of your definitions in one file. You can als
 
 ## Parser
 
-The parser recognizes two placeholders:
+The parser recognizes three placeholders:
 * `#{key.path}` - will resolve to a random value from the list of data definitions using the provided key path; The
  resolved value may itself be an expression. If the path resolves to a list of keys (instead of values),
- a random one of them will be returned.
+ a random one of them will be returned. 
+ The value will always be taken from a single locale (the first one which contains values for the path).
+* `#{{key.path}}` (since SNAPSHOT) - like above, but will return a random value from the superset of all locales' 
+ values.
 * `#` - will resolve to a random digit between 0 and 9 
 
-Dummy4j can resolve expressions, which are a mix of the aforementioned placeholders and other characters
-, e.g.:
+Dummy4j can resolve expressions, which are a mix of the aforementioned placeholders and other characters, e.g.:
 
 * `#{name.male_first_name} #{name.last_name}`
 * `##-###`

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -42,13 +42,13 @@ If you choose to, you can place all of your definitions in one file. You can als
 ## Parser
 
 The parser recognizes three placeholders:
-* `#{key.path}` (single-locale placeholder) - will resolve to a random value from the list of data definitions using
+* `#{path.to.key}` (single-locale placeholder) - will resolve to a random value from the list of data definitions using
  the provided key path; The resolved value may itself be an expression. If the path resolves to a list of keys
  (instead of values), a random one of them will be returned.
  The value will always be taken from a single locale - the first one which contains values for the path, unless the
  placeholder is part of a nested expression in which case it will always resolve only to its parent expression's 
  locale. The parent expression's locale is the locale of the first placeholder that was resolved within it.
-* `#{{key.path}}` (multi-locale placeholder, since SNAPSHOT) - like above, but will return a random value from the
+* `#{{path.to.key}}` (multi-locale placeholder, since SNAPSHOT) - like above, but will return a random value from the
   superset of all locales' values, regardless of whether it is part of a nested expression.
 * `#` (digit) - will resolve to a random digit between 0 and 9
 

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -55,6 +55,11 @@ Dummy4j can resolve expressions, which are a mix of the aforementioned placehold
 The parser will first try to resolve the key in the locale which is first on the list. Failing that, it will keep
 going down the list until it resolves it or returns NULL.
 
+It is also possible to resolve nested expressions, e.g.:
+`#{key1.#{key2}}`.
+In that case, the expression `#{key2}` will be resolved first and its result will be used to resolve
+the root expression.
+
 ## Providing custom files
 
 Let's say you have created the following definitions file:

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -39,9 +39,9 @@ files of the same name within the same path may override each other.
 
 If you choose to, you can place all of your definitions in one file. You can also spread them out over several files.
 
-## Parser
+## Expression resolver
 
-The parser recognizes three placeholders:
+The expression resolver recognizes three placeholders:
 * `#{path.to.key}` (single-locale placeholder) - will resolve to a random value from the list of data definitions using
  the provided key path; The resolved value may itself be an expression. If the path resolves to a list of keys
  (instead of values), a random one of them will be returned.
@@ -57,8 +57,8 @@ Dummy4j can resolve expressions, which are a mix of the aforementioned placehold
 * `#{name.male_first_name} #{name.last_name}`
 * `##-###`
 
-The parser will first try to resolve the path in the locale which is first on the list. Failing that, it will keep
-going down the list until it resolves it or returns NULL.
+The expression resolver will first try to resolve the path in the locale which is first on the list. Failing that,
+it will keep going down the list until it resolves it or returns NULL.
 
 It is also possible to resolve nested expressions, e.g.:
 `#{key1.#{key2}}`.

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -43,7 +43,8 @@ If you choose to, you can place all of your definitions in one file. You can als
 
 The parser recognizes two placeholders:
 * `#{key.path}` - will resolve to a random value from the list of data definitions using the provided key path; The
- resolved value may itself be an expression
+ resolved value may itself be an expression. If the path resolves to a list of keys (instead of values),
+ a random one of them will be returned.
 * `#` - will resolve to a random digit between 0 and 9 
 
 Dummy4j can resolve expressions, which are a mix of the aforementioned placeholders and other characters
@@ -52,13 +53,14 @@ Dummy4j can resolve expressions, which are a mix of the aforementioned placehold
 * `#{name.male_first_name} #{name.last_name}`
 * `##-###`
 
-The parser will first try to resolve the key in the locale which is first on the list. Failing that, it will keep
+The parser will first try to resolve the path in the locale which is first on the list. Failing that, it will keep
 going down the list until it resolves it or returns NULL.
 
 It is also possible to resolve nested expressions, e.g.:
 `#{key1.#{key2}}`.
-In that case, the expression `#{key2}` will be resolved first and its result will be used to resolve
-the root expression.
+In that case, the placeholder `#{key2}` will be resolved first and its result will be used to resolve
+the root placeholder. This can be especially useful for picking a random key
+(`#{key1.#{key1}}` will resolve a random key from `key1`).
 
 ## Providing custom files
 

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -43,7 +43,7 @@ If you choose to, you can place all of your definitions in one file. You can als
 
 The expression resolver recognizes three placeholders:
 * `#{path.to.key}` (single-locale placeholder) - will resolve to a random value from the list of data definitions using
- the provided key path; The resolved value may itself be an expression. If the path resolves to a list of keys
+ the provided key path; the resolved value may itself be an expression. If the path resolves to a list of keys
  (instead of values), a random one of them will be returned.
  The value will always be taken from a single locale - the first one which contains values for the path, unless the
  placeholder is part of a nested expression in which case it will always resolve only to its parent expression's 

--- a/extending-dummy4j.md
+++ b/extending-dummy4j.md
@@ -45,12 +45,12 @@ The parser recognizes three placeholders:
 * `#{key.path}` (single-locale placeholder) - will resolve to a random value from the list of data definitions using
  the provided key path; The resolved value may itself be an expression. If the path resolves to a list of keys
  (instead of values), a random one of them will be returned.
- The value will always be taken from a single locale (the first one which contains values for the path, unless the
+ The value will always be taken from a single locale - the first one which contains values for the path, unless the
  placeholder is part of a nested expression in which case it will always resolve only to its parent expression's 
- locale).
+ locale. The parent expression's locale is the locale of the first placeholder that was resolved within it.
 * `#{{key.path}}` (multi-locale placeholder, since SNAPSHOT) - like above, but will return a random value from the
   superset of all locales' values, regardless of whether it is part of a nested expression.
-* `#` (number) - will resolve to a random digit between 0 and 9
+* `#` (digit) - will resolve to a random digit between 0 and 9
 
 Dummy4j can resolve expressions, which are a mix of the aforementioned placeholders and other characters, e.g.:
 

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -59,7 +59,7 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
     }
 
     @Override
-    public Set<String> getKeysFor(String path) {
+    public Set<String> listValues(String path) {
         return locales.stream()
                 .map(l -> localizedDefinitions.get(l).resolve(path))
                 .flatMap(Collection::stream)

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -24,7 +24,7 @@ import static java.util.stream.Collectors.toSet;
 public final class DefaultExpressionResolver implements ExpressionResolver {
 
     private static final String ESCAPE_PREFIX = "\\\\?";
-    private static final Pattern VARIABLE_PATTERN = Pattern.compile("#\\{(.*?)}");
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("#\\{((?:(?!#\\{|}).)*)}");
     private static final Pattern DIGIT_PATTERN = Pattern.compile(ESCAPE_PREFIX + "#(?!\\{)");
 
     final RandomService randomService;

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -5,13 +5,16 @@ import dev.codesoapbox.dummy4j.definitions.LocalizedDummyDefinitions;
 import dev.codesoapbox.dummy4j.definitions.providers.DefinitionProvider;
 import dev.codesoapbox.dummy4j.exceptions.MissingLocaleDefinitionsException;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * A default implementation of the expression resolver
@@ -54,6 +57,14 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
         return resolve(result);
     }
 
+    @Override
+    public Set<String> getKeysFor(String path) {
+        return locales.stream()
+                .map(l -> localizedDefinitions.get(l).getKeysFor(path))
+                .flatMap(Collection::stream)
+                .collect(toSet());
+    }
+
     private String resolveAllKeysAndDigits(String expression) {
         final String expressionWithResolvedKeys = replaceKeyPlaceholders(expression);
         return replaceDigitPlaceholders(expressionWithResolvedKeys);
@@ -76,7 +87,7 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
     private String replace(String expression, Matcher expressionMatcher, Supplier<String> replacementSupplier) {
         final StringBuffer b = new StringBuffer(expression.length());
         while (expressionMatcher.find()) {
-            if(expressionMatcher.group().charAt(0) == '\\') {
+            if (expressionMatcher.group().charAt(0) == '\\') {
                 expressionMatcher.appendReplacement(b, expressionMatcher.group().substring(1));
             } else {
                 expressionMatcher.appendReplacement(b, Matcher.quoteReplacement(replacementSupplier.get()));

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -121,8 +121,8 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
 
     /**
      * Resolves a single path to a random value from a single locale.
-     * If originalLocale is empty, the method first looks into the primary locale and then goes to the next ones
-     * in order if a path could not be resolved.
+     * If originalLocale is empty, the method first looks into the primary locale and then goes to the next ones,
+     * preserving order, if a path could not be resolved.
      * If originalLocale is not empty, the method looks only into that locale.
      * Note that this method does not perform any parsing and thus will not resolve values which themselves are
      * expressions.

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -5,16 +5,13 @@ import dev.codesoapbox.dummy4j.definitions.LocalizedDummyDefinitions;
 import dev.codesoapbox.dummy4j.definitions.providers.DefinitionProvider;
 import dev.codesoapbox.dummy4j.exceptions.MissingLocaleDefinitionsException;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * A default implementation of the expression resolver
@@ -56,14 +53,6 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
         }
 
         return resolve(expressionWithResolvedKeys);
-    }
-
-    @Override
-    public Set<String> listValues(String path) {
-        return locales.stream()
-                .map(l -> localizedDefinitions.get(l).resolve(path))
-                .flatMap(Collection::stream)
-                .collect(toSet());
     }
 
     private String replaceKeyPlaceholders(String expression) {

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -49,12 +49,13 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
 
     @Override
     public String resolve(String expression) {
-        final String result = resolveAllKeysAndDigits(expression);
+        final String expressionWithResolvedKeys = replaceKeyPlaceholders(expression);
 
-        if (!VARIABLE_PATTERN.matcher(result).find()) {
-            return result;
+        if (!VARIABLE_PATTERN.matcher(expressionWithResolvedKeys).find()) {
+            return replaceDigitPlaceholders(expressionWithResolvedKeys);
         }
-        return resolve(result);
+
+        return resolve(expressionWithResolvedKeys);
     }
 
     @Override
@@ -63,11 +64,6 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
                 .map(l -> localizedDefinitions.get(l).resolve(path))
                 .flatMap(Collection::stream)
                 .collect(toSet());
-    }
-
-    private String resolveAllKeysAndDigits(String expression) {
-        final String expressionWithResolvedKeys = replaceKeyPlaceholders(expression);
-        return replaceDigitPlaceholders(expressionWithResolvedKeys);
     }
 
     private String replaceKeyPlaceholders(String expression) {

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -5,6 +5,7 @@ import dev.codesoapbox.dummy4j.definitions.LocalizedDummyDefinitions;
 import dev.codesoapbox.dummy4j.definitions.providers.DefinitionProvider;
 import dev.codesoapbox.dummy4j.exceptions.MissingLocaleDefinitionsException;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -12,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 /**
  * A default implementation of the expression resolver
@@ -21,7 +23,8 @@ import static java.util.Collections.singletonList;
 public final class DefaultExpressionResolver implements ExpressionResolver {
 
     private static final String ESCAPE_PREFIX = "\\\\?";
-    private static final Pattern VARIABLE_PATTERN = Pattern.compile("#\\{((?:(?!#\\{|}).)*)}");
+    private static final Pattern MULTI_LOCALE_VARIABLE_PATTERN = Pattern.compile("#\\{{2}((?:(?!#\\{|}).)*)}{2}");
+    private static final Pattern SINGLE_LOCALE_VARIABLE_PATTERN = Pattern.compile("#\\{(?!\\{)((?:(?!#\\{|}).)*)}");
     private static final Pattern DIGIT_PATTERN = Pattern.compile(ESCAPE_PREFIX + "#(?!\\{)");
 
     final RandomService randomService;
@@ -46,27 +49,20 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
 
     @Override
     public String resolve(String expression) {
-        final String expressionWithResolvedKeys = replaceKeyPlaceholders(expression);
+        do {
+            expression = replaceMultiLocalePlaceholders(expression);
+            expression = replaceSingleLocalePlaceholders(expression);
+        } while (MULTI_LOCALE_VARIABLE_PATTERN.matcher(expression).find()
+                || SINGLE_LOCALE_VARIABLE_PATTERN.matcher(expression).find());
 
-        if (!VARIABLE_PATTERN.matcher(expressionWithResolvedKeys).find()) {
-            return replaceDigitPlaceholders(expressionWithResolvedKeys);
-        }
-
-        return resolve(expressionWithResolvedKeys);
+        return replaceDigitPlaceholders(expression);
     }
 
-    private String replaceKeyPlaceholders(String expression) {
-        final Matcher expressionMatcher = VARIABLE_PATTERN.matcher(expression);
+    private String replaceMultiLocalePlaceholders(String expression) {
+        final Matcher expressionMatcher = MULTI_LOCALE_VARIABLE_PATTERN.matcher(expression);
 
         return replace(expression, expressionMatcher,
-                () -> resolveKey(expressionMatcher.group(1)));
-    }
-
-    private String replaceDigitPlaceholders(String expressionWithResolvedKeys) {
-        final Matcher digitMatcher = DIGIT_PATTERN.matcher(expressionWithResolvedKeys);
-
-        return replace(expressionWithResolvedKeys, digitMatcher,
-                () -> String.valueOf(randomService.nextInt(9)));
+                () -> resolvePathWithinAllLocales(expressionMatcher.group(1)));
     }
 
     private String replace(String expression, Matcher expressionMatcher, Supplier<String> replacementSupplier) {
@@ -84,19 +80,22 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
     }
 
     /**
-     * Resolves a single key to a random value.
+     * Resolves a single path to a random value from a superset of all locale values.
      * Note that this method does not perform any parsing and thus will not resolve values which themselves are
      * expressions.
      *
-     * @param key the key to resolved
-     * @return a random value based on the key
+     * @param path the path to resolved
+     * @return a random value based on the path
      */
-    private String resolveKey(String key) {
-        for (String locale : locales) {
-            List<String> result = localizedDefinitions.get(locale).resolve(key);
-            if (result != null && !result.isEmpty()) {
-                return getRandom(result);
-            }
+    private String resolvePathWithinAllLocales(String path) {
+        List<String> result = locales.stream()
+                .map(locale -> localizedDefinitions.get(locale).resolve(path))
+                .flatMap(Collection::stream)
+                .distinct()
+                .collect(toList());
+
+        if (!result.isEmpty()) {
+            return getRandom(result);
         }
         return "";
     }
@@ -104,5 +103,39 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
     private String getRandom(List<String> result) {
         int i = randomService.nextInt(result.size() - 1);
         return result.get(i);
+    }
+
+    private String replaceSingleLocalePlaceholders(String expression) {
+        final Matcher expressionMatcher = SINGLE_LOCALE_VARIABLE_PATTERN.matcher(expression);
+
+        return replace(expression, expressionMatcher,
+                () -> resolvePathWithinSingleLocale(expressionMatcher.group(1)));
+    }
+
+    /**
+     * Resolves a single path to a random value from a single locale.
+     * The method first looks into the primary locale and then goes to the next ones in order if a path could not be
+     * resolved.
+     * Note that this method does not perform any parsing and thus will not resolve values which themselves are
+     * expressions.
+     *
+     * @param path the path to resolved
+     * @return a random value based on the path
+     */
+    private String resolvePathWithinSingleLocale(String path) {
+        for (String locale : locales) {
+            List<String> result = localizedDefinitions.get(locale).resolve(path);
+            if (result != null && !result.isEmpty()) {
+                return getRandom(result);
+            }
+        }
+        return "";
+    }
+
+    private String replaceDigitPlaceholders(String expressionWithResolvedKeys) {
+        final Matcher digitMatcher = DIGIT_PATTERN.matcher(expressionWithResolvedKeys);
+
+        return replace(expressionWithResolvedKeys, digitMatcher,
+                () -> String.valueOf(randomService.nextInt(9)));
     }
 }

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -8,6 +8,7 @@ import dev.codesoapbox.dummy4j.exceptions.MissingLocaleDefinitionsException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -90,6 +91,7 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
     private String resolvePathWithinAllLocales(String path) {
         List<String> result = locales.stream()
                 .map(locale -> localizedDefinitions.get(locale).resolve(path))
+                .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .distinct()
                 .collect(toList());

--- a/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/DefaultExpressionResolver.java
@@ -60,7 +60,7 @@ public final class DefaultExpressionResolver implements ExpressionResolver {
     @Override
     public Set<String> getKeysFor(String path) {
         return locales.stream()
-                .map(l -> localizedDefinitions.get(l).getKeysFor(path))
+                .map(l -> localizedDefinitions.get(l).resolve(path))
                 .flatMap(Collection::stream)
                 .collect(toSet());
     }

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -11,17 +11,21 @@ public interface ExpressionResolver {
      * Resolves an expression like:
      * {@code #{name.male_first_name} #{name.last_name} }
      * <p>
-     * Definition keys are defined as {@code #{definition.path}}.
+     * Placeholders are defined as {@code #{definition.path}}.
      * <p>
      * Digits are defined simply as {@code #}.
      * <p>
-     * Placeholders which have no definitions will be removed.
-     * The method first looks into the locale which was passed as first in the list and then goes to the next
-     * ones in order if a key could not be resolved.
+     * Placeholders which don't resolve to anything will be removed.
+     * <p>
+     * The method first looks into the primary locale and then goes to the next ones in order if a key could not be
+     * resolved.
+     * <p>
+     * If a path does not resolve to a value or list of values, returns a random key contained directly within it
+     * (if possible).
      * <p>
      * It is possible to resolve nested expressions like "{@code #{key1.#{key2}}}" (since SNAPSHOT).
-     * In that case, the expression "{@code #{key2}}" will be resolved first and its result will be used to resolve
-     * the root expression.
+     * In that case, the placeholder "{@code #{key2}}" will be resolved first and its result will be used to resolve
+     * the root placeholder.
      *
      * @param expression the expression to evaluate
      * @return a resolved random expression

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -20,7 +20,7 @@ public interface ExpressionResolver {
      * <p>
      * Digits are defined simply as {@code #}.
      * <p>
-     * Placeholders which don't resolve to anything will be removed.
+     * Placeholders which don't resolve to anything will be removed from the expression.
      * <p>
      * Since SNAPSHOT:
      * <p>

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -9,17 +9,20 @@ public interface ExpressionResolver {
      * Resolves an expression like:
      * {@code #{name.male_first_name} #{name.last_name} }
      * <p>
-     * Placeholders are defined as {@code #{definition.path}}.
+     * Single-locale placeholders are defined as {@code #{definition.path}}.
+     * They resolve to a random value from a single locale.
+     * <p>
+     * Multi-locale placeholders (since SNAPSHOT) are defined as {@code #{{definition.path}}}.
+     * They resolve to a random value from a superset of all locales' values.
      * <p>
      * Digits are defined simply as {@code #}.
      * <p>
      * Placeholders which don't resolve to anything will be removed.
      * <p>
-     * The method first looks into the primary locale and then goes to the next ones in order if a key could not be
-     * resolved.
+     * Since SNAPSHOT:
      * <p>
-     * If a path does not resolve to a value or list of values, returns a random key contained directly within it
-     * (if possible).
+     * If a path exists but does not resolve to a value or list of values, returns a random key contained directly
+     * within it.
      * <p>
      * It is possible to resolve nested expressions like "{@code #{key1.#{key2}}}" (since SNAPSHOT).
      * In that case, the placeholder "{@code #{key2}}" will be resolved first and its result will be used to resolve

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -9,13 +9,13 @@ public interface ExpressionResolver {
      * Resolves an expression like:
      * {@code #{name.male_first_name} #{name.last_name} }
      * <p>
-     * Single-locale placeholders are defined as {@code #{definition.path}}.
+     * Single-locale placeholders are defined as {@code #{path.to.key}}.
      * They resolve to a random value from a single locale - the first one which contains values for the path, unless
      * the placeholder is part of a nested expression in which case it will always resolve only to its parent
      * expression's locale. The parent expression's locale is the locale of the first placeholder that was resolved
      * within it.
      * <p>
-     * Multi-locale placeholders (since SNAPSHOT) are defined as {@code #{{definition.path}}}.
+     * Multi-locale placeholders (since SNAPSHOT) are defined as {@code #{{path.to.key}}}.
      * They resolve to a random value from a superset of all locales' values.
      * <p>
      * Digits are defined simply as {@code #}.

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -18,6 +18,10 @@ public interface ExpressionResolver {
      * Placeholders which have no definitions will be removed.
      * The method first looks into the locale which was passed as first in the list and then goes to the next
      * ones in order if a key could not be resolved.
+     * <p>
+     * It is possible to resolve nested expressions like "{@code #{key1.#{key2}}}" (since SNAPSHOT).
+     * In that case, the expression "{@code #{key2}}" will be resolved first and its result will be used to resolve
+     * the root expression.
      *
      * @param expression the expression to evaluate
      * @return a resolved random expression

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -33,9 +33,9 @@ public interface ExpressionResolver {
     String resolve(String expression);
 
     /**
-     * Returns a list of all keys contained directly within a given path.
+     * Returns a list of values or keys contained directly within a given path.
      * <p>
-     * The keys returned will be a superset of keys in every locale.
+     * The values returned will be a superset of values in every locale.
      * <p>
      * This method does not support expressions.
      *
@@ -43,5 +43,5 @@ public interface ExpressionResolver {
      * @return a list of keys
      * @since SNAPSHOT
      */
-    Set<String> getKeysFor(String path);
+    Set<String> listValues(String path);
 }

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -1,5 +1,7 @@
 package dev.codesoapbox.dummy4j;
 
+import java.util.Set;
+
 /**
  * @since 0.5.0
  */
@@ -21,4 +23,17 @@ public interface ExpressionResolver {
      * @return a resolved random expression
      */
     String resolve(String expression);
+
+    /**
+     * Returns a list of all keys contained directly within a given path.
+     * <p>
+     * The keys returned will be a superset of keys in every locale.
+     * <p>
+     * This method does not support expressions.
+     *
+     * @param path the path whose sub-keys should be returned
+     * @return a list of keys
+     * @since SNAPSHOT
+     */
+    Set<String> getKeysFor(String path);
 }

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -10,7 +10,10 @@ public interface ExpressionResolver {
      * {@code #{name.male_first_name} #{name.last_name} }
      * <p>
      * Single-locale placeholders are defined as {@code #{definition.path}}.
-     * They resolve to a random value from a single locale.
+     * They resolve to a random value from a single locale - the first one which contains values for the path, unless
+     * the placeholder is part of a nested expression in which case it will always resolve only to its parent
+     * expression's locale. The parent expression's locale is the locale of the first placeholder that was resolved
+     * within it.
      * <p>
      * Multi-locale placeholders (since SNAPSHOT) are defined as {@code #{{definition.path}}}.
      * They resolve to a random value from a superset of all locales' values.

--- a/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ExpressionResolver.java
@@ -1,7 +1,5 @@
 package dev.codesoapbox.dummy4j;
 
-import java.util.Set;
-
 /**
  * @since 0.5.0
  */
@@ -31,17 +29,4 @@ public interface ExpressionResolver {
      * @return a resolved random expression
      */
     String resolve(String expression);
-
-    /**
-     * Returns a list of values or keys contained directly within a given path.
-     * <p>
-     * The values returned will be a superset of values in every locale.
-     * <p>
-     * This method does not support expressions.
-     *
-     * @param path the path whose sub-keys should be returned
-     * @return a list of keys
-     * @since SNAPSHOT
-     */
-    Set<String> listValues(String path);
 }

--- a/src/main/java/dev/codesoapbox/dummy4j/ResolvedValue.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ResolvedValue.java
@@ -1,0 +1,46 @@
+package dev.codesoapbox.dummy4j;
+
+import java.util.Objects;
+
+public final class ResolvedValue {
+
+    private final String locale;
+    private final String value;
+
+    private ResolvedValue(String locale, String value) {
+        if (locale == null) {
+            throw new IllegalArgumentException("Locale cannot be null");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("Value cannot be null");
+        }
+
+        this.locale = locale;
+        this.value = value;
+    }
+
+    public static ResolvedValue of(String locale, String value) {
+        return new ResolvedValue(locale, value);
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ResolvedValue)) return false;
+        ResolvedValue that = (ResolvedValue) o;
+        return locale.equals(that.locale) && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(locale, value);
+    }
+}

--- a/src/main/java/dev/codesoapbox/dummy4j/ResolvedValue.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/ResolvedValue.java
@@ -33,8 +33,12 @@ public final class ResolvedValue {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ResolvedValue)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ResolvedValue)) {
+            return false;
+        }
         ResolvedValue that = (ResolvedValue) o;
         return locale.equals(that.locale) && value.equals(that.value);
     }

--- a/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitions.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitions.java
@@ -1,6 +1,7 @@
 package dev.codesoapbox.dummy4j.definitions;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A collection of resolvable dummy data definitions for a given locale.
@@ -13,10 +14,19 @@ public interface LocalizedDummyDefinitions {
     String getLocale();
 
     /**
-     * Return a list of all possible values for a given key.
+     * Returns a list of all possible values for a given path.
      *
-     * @param key the key to resolve
-     * @return a list of all values assigned to the key
+     * @param path the path to resolve
+     * @return a list of all values assigned to the path
      */
-    List<String> resolve(String key);
+    List<String> resolve(String path);
+
+    /**
+     * Returns a list of all keys contained directly within a given path.
+     *
+     * @param path the path whose sub-keys should be returned
+     * @return a list of keys
+     * @since SNAPSHOT
+     */
+    Set<String> getKeysFor(String path);
 }

--- a/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitions.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitions.java
@@ -1,7 +1,6 @@
 package dev.codesoapbox.dummy4j.definitions;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * A collection of resolvable dummy data definitions for a given locale.
@@ -15,18 +14,11 @@ public interface LocalizedDummyDefinitions {
 
     /**
      * Returns a list of all possible values for a given path.
+     * If the path does not resolve to a value or list of values, returns a list
+     * of all keys contained directly within it.
      *
      * @param path the path to resolve
-     * @return a list of all values assigned to the path
+     * @return a list of all values assigned to the path or a list of all keys contained within it
      */
     List<String> resolve(String path);
-
-    /**
-     * Returns a list of all keys contained directly within a given path.
-     *
-     * @param path the path whose sub-keys should be returned
-     * @return a list of keys
-     * @since SNAPSHOT
-     */
-    Set<String> getKeysFor(String path);
 }

--- a/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitions.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitions.java
@@ -14,7 +14,10 @@ public interface LocalizedDummyDefinitions {
 
     /**
      * Returns a list of all possible values for a given path.
-     * If the path does not resolve to a value or list of values, returns a list
+     * <p>
+     * Since SNAPSHOT:
+     * <p>
+     * If the path exists but does not resolve to a value or list of values, returns a list
      * of all keys contained directly within it.
      *
      * @param path the path to resolve

--- a/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMap.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMap.java
@@ -41,8 +41,7 @@ public final class LocalizedDummyDefinitionsMap implements LocalizedDummyDefinit
     @SuppressWarnings("unchecked")
     private List<String> resolveResult(String[] keys, Object result) {
         if (result instanceof Map) {
-            String[] keysWithoutRoot = Arrays.copyOfRange(keys, 1, keys.length);
-            return resolve((Map<String, Object>) result, keysWithoutRoot);
+            return resolveMap(keys, (Map<String, Object>) result);
         }
 
         if (result instanceof List) {
@@ -50,6 +49,14 @@ public final class LocalizedDummyDefinitionsMap implements LocalizedDummyDefinit
         }
 
         return singletonList(String.valueOf(result));
+    }
+
+    private List<String> resolveMap(String[] keys, Map<String, Object> result) {
+        if(keys.length == 1) {
+            return new ArrayList<>(result.keySet());
+        }
+        String[] keysWithoutRoot = Arrays.copyOfRange(keys, 1, keys.length);
+        return resolve(result, keysWithoutRoot);
     }
 
     @SuppressWarnings("unchecked")
@@ -61,35 +68,6 @@ public final class LocalizedDummyDefinitionsMap implements LocalizedDummyDefinit
         return result.stream()
                 .map(String::valueOf)
                 .collect(toList());
-    }
-
-    @Override
-    public Set<String> getKeysFor(String path) {
-        String[] keys = path.split("\\.");
-
-        return getKeysFor(map, keys);
-    }
-
-    private Set<String> getKeysFor(Map<String, Object> subMap, String[] keys) {
-        if (!subMap.containsKey(keys[0])) {
-            return emptySet();
-        }
-
-        return getKeysForResult(keys, subMap.get(keys[0]));
-    }
-
-    @SuppressWarnings("unchecked")
-    private Set<String> getKeysForResult(String[] keys, Object result) {
-        if (!(result instanceof Map)) {
-            return emptySet();
-        }
-
-        if(keys.length == 1) {
-            return ((Map<String, Object>) result).keySet();
-        }
-
-        String[] keysWithoutRoot = Arrays.copyOfRange(keys, 1, keys.length);
-        return getKeysFor((Map<String, Object>) result, keysWithoutRoot);
     }
 
     @Override

--- a/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMap.java
+++ b/src/main/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMap.java
@@ -1,12 +1,8 @@
 package dev.codesoapbox.dummy4j.definitions;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -28,8 +24,8 @@ public final class LocalizedDummyDefinitionsMap implements LocalizedDummyDefinit
     }
 
     @Override
-    public List<String> resolve(String key) {
-        String[] keys = key.split("\\.");
+    public List<String> resolve(String path) {
+        String[] keys = path.split("\\.");
 
         return resolve(map, keys);
     }
@@ -65,6 +61,35 @@ public final class LocalizedDummyDefinitionsMap implements LocalizedDummyDefinit
         return result.stream()
                 .map(String::valueOf)
                 .collect(toList());
+    }
+
+    @Override
+    public Set<String> getKeysFor(String path) {
+        String[] keys = path.split("\\.");
+
+        return getKeysFor(map, keys);
+    }
+
+    private Set<String> getKeysFor(Map<String, Object> subMap, String[] keys) {
+        if (!subMap.containsKey(keys[0])) {
+            return emptySet();
+        }
+
+        return getKeysForResult(keys, subMap.get(keys[0]));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> getKeysForResult(String[] keys, Object result) {
+        if (!(result instanceof Map)) {
+            return emptySet();
+        }
+
+        if(keys.length == 1) {
+            return ((Map<String, Object>) result).keySet();
+        }
+
+        String[] keysWithoutRoot = Arrays.copyOfRange(keys, 1, keys.length);
+        return getKeysFor((Map<String, Object>) result, keysWithoutRoot);
     }
 
     @Override

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverForMultipleLanguagesTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverForMultipleLanguagesTest.java
@@ -1,0 +1,153 @@
+package dev.codesoapbox.dummy4j;
+
+import dev.codesoapbox.dummy4j.definitions.LocalizedDummyDefinitions;
+import dev.codesoapbox.dummy4j.definitions.LocalizedDummyDefinitionsMap;
+import dev.codesoapbox.dummy4j.definitions.providers.DefinitionProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultExpressionResolverForMultipleLanguagesTest {
+
+    private static final String EN = "en";
+    private static final String FR = "fr";
+    private static final String FLAVOUR = "flavour";
+    private static final String FRUIT = "fruit";
+    private static final String SPICY = "spicy";
+    private static final String MIXED = "mixed";
+    private static final String MIXED_MULTI = "mixed_multi";
+    private static final String MIXED_FLAVOURS = String.format("#{%s.%s} - #{%s.%s}", FLAVOUR, FRUIT, FLAVOUR, SPICY);
+    private static final String MIXED_FLAVOURS_MULTI = String.format("#{{%s.%s}} - #{{%s.%s}}",
+            FLAVOUR, FRUIT, FLAVOUR, SPICY);
+
+    @Mock
+    private DefinitionProvider definitionProvider;
+
+    @Mock
+    private RandomService randomService;
+
+    private DefaultExpressionResolver expressionResolver;
+
+    @BeforeEach
+    void setUp() {
+        LocalizedDummyDefinitions english = new LocalizedDummyDefinitionsMap(EN, createEnglishDefinitions());
+        LocalizedDummyDefinitions french = new LocalizedDummyDefinitionsMap(FR, createFrenchDefinitions());
+
+        when(definitionProvider.get())
+                .thenReturn(asList(english, french));
+
+        expressionResolver = new DefaultExpressionResolver(asList(EN, FR), randomService, definitionProvider);
+    }
+
+    private Map<String, Object> createEnglishDefinitions() {
+        Map<String, Object> flavours = new HashMap<>();
+        flavours.put(FRUIT, Arrays.asList("lemon", "raspberry"));
+        flavours.put(SPICY, Arrays.asList("pumpkin spice", "cinnamon"));
+        flavours.put(MIXED, EN + ": " + MIXED_FLAVOURS);
+        flavours.put(MIXED_MULTI, EN + ": " + MIXED_FLAVOURS_MULTI);
+
+        Map<String, Object> rootMap = new HashMap<>();
+        rootMap.put(FLAVOUR, flavours);
+
+        return rootMap;
+    }
+
+    private Map<String, Object> createFrenchDefinitions() {
+        Map<String, Object> flavours = new HashMap<>();
+        flavours.put(FRUIT, Arrays.asList("citron", "framboise"));
+        flavours.put(SPICY, Arrays.asList("epices de potiron", "cannelle"));
+        flavours.put(MIXED, FR + ": " + MIXED_FLAVOURS);
+        flavours.put(MIXED_MULTI, FR + ": " + MIXED_FLAVOURS_MULTI);
+
+        Map<String, Object> rootMap = new HashMap<>();
+        rootMap.put(FLAVOUR, flavours);
+
+        return rootMap;
+    }
+
+    @Test
+    void shouldResolveNestedSingleLocalePlaceholdersInMultiLocaleExpressionFromAllLocales() {
+        Set<String> expected = new HashSet<>();
+        expected.add("en: raspberry - cinnamon");
+        expected.add("fr: framboise - cannelle");
+
+        Set<String> result = new HashSet<>();
+
+        mockRandomServiceForFullRange();
+
+        for (int i = 0; i < 10; i++) {
+            result.add(expressionResolver.resolve("#{{" + FLAVOUR + "." + MIXED + "}}"));
+        }
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldResolveNestedSingleLocalePlaceholdersInSingleLocaleExpression() {
+        Set<String> expected = new HashSet<>();
+        expected.add("en: raspberry - cinnamon");
+
+        Set<String> result = new HashSet<>();
+
+        mockRandomServiceForFullRange();
+
+        for (int i = 0; i < 10; i++) {
+            result.add(expressionResolver.resolve("#{" + FLAVOUR + "." + MIXED + "}"));
+        }
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldResolveNestedMultiLocalePlaceholdersInSingleLocaleExpression() {
+        Set<String> notExpected = new HashSet<>();
+        notExpected.add("en: raspberry - cinnamon");
+
+        Set<String> result = new HashSet<>();
+
+        mockRandomServiceForFullRange();
+
+        for (int i = 0; i < 10; i++) {
+            result.add(expressionResolver.resolve("#{" + FLAVOUR + "." + MIXED_MULTI + "}"));
+        }
+        assertNotEquals(notExpected, result);
+    }
+
+    private void mockRandomServiceForFullRange() {
+        AtomicInteger counter = new AtomicInteger();
+        doAnswer(inv -> {
+            int value = counter.getAndIncrement();
+            if (value < (int) inv.getArgument(0)) {
+                return value;
+            }
+            return inv.getArgument(0);
+        }).when(randomService).nextInt(anyInt());
+    }
+
+    @Test
+    void shouldResolveNestedMultiLocalePlaceholdersInMultiLocaleExpressionFromAllLocales() {
+        Set<String> notExpected = new HashSet<>();
+        notExpected.add("en: raspberry - cinnamon");
+        notExpected.add("fr: framboise - cannelle");
+
+        Set<String> result = new HashSet<>();
+
+        mockRandomServiceForFullRange();
+
+        for (int i = 0; i < 10; i++) {
+            result.add(expressionResolver.resolve("#{{" + FLAVOUR + "." + MIXED_MULTI + "}}"));
+        }
+        assertNotEquals(notExpected, result);
+    }
+}

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverForMultipleLanguagesTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverForMultipleLanguagesTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class DefaultExpressionResolverForMultipleLanguagesTest {
+class DefaultExpressionResolverForMultipleLanguagesTest {
 
     private static final String EN = "en";
     private static final String FR = "fr";

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.*;
 
+import static java.util.Arrays.*;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,9 +41,9 @@ class DefaultExpressionResolverTest {
         LocalizedDummyDefinitions dummyDefinitionsFr =
                 new LocalizedDummyDefinitionsMap(localeFr, buildDefinitionMapFr());
         when(definitionProvider.get())
-                .thenReturn(Arrays.asList(dummyDefinitionsEn, dummyDefinitionsFr));
+                .thenReturn(asList(dummyDefinitionsEn, dummyDefinitionsFr));
 
-        expressionResolver = new DefaultExpressionResolver(Arrays.asList(localeEn, localeFr), randomService,
+        expressionResolver = new DefaultExpressionResolver(asList(localeEn, localeFr), randomService,
                 definitionProvider);
     }
 

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -233,8 +233,8 @@ class DefaultExpressionResolverTest {
     }
 
     @Test
-    void shouldResolveMultiLocalePlaceholderWhenSomeDefinitionsReturnNull() {
-        LocalizedDummyDefinitions enDefinitions = mockLocalizedDefinitions("en", null);
+    void shouldResolveMultiLocalePlaceholderWhenSomeDefinitionsReturnEmpty() {
+        LocalizedDummyDefinitions enDefinitions = mockLocalizedDefinitions("en", emptyList());
         LocalizedDummyDefinitions frDefinitions = mockLocalizedDefinitions("fr", singletonList("value"));
         when(definitionProvider.get())
                 .thenReturn(asList(enDefinitions, frDefinitions));
@@ -245,9 +245,9 @@ class DefaultExpressionResolverTest {
     }
 
     @Test
-    void shouldReturnEmptyStringWhenResolvingMultiLocalePlaceholderAndAllDefinitionsReturnNull() {
-        LocalizedDummyDefinitions enDefinitions = mockLocalizedDefinitions("en", null);
-        LocalizedDummyDefinitions frDefinitions = mockLocalizedDefinitions("fr", null);
+    void shouldReturnEmptyStringWhenResolvingMultiLocalePlaceholderAndAllDefinitionsReturnEmpty() {
+        LocalizedDummyDefinitions enDefinitions = mockLocalizedDefinitions("en", emptyList());
+        LocalizedDummyDefinitions frDefinitions = mockLocalizedDefinitions("fr", emptyList());
         when(definitionProvider.get())
                 .thenReturn(asList(enDefinitions, frDefinitions));
         expressionResolver = new DefaultExpressionResolver(asList("en", "fr"), randomService, definitionProvider);

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -56,6 +56,7 @@ class DefaultExpressionResolverTest {
 
         Map<String, Object> rootMap = new HashMap<>();
         rootMap.put("something", nestedMap);
+        rootMap.put("somethingKey", "deep");
 
         return rootMap;
     }
@@ -129,9 +130,15 @@ class DefaultExpressionResolverTest {
     }
 
     @Test
-    void shouldResolveExpressionWithinExpression() {
+    void shouldResolveExpressionWhichResolvesToExpression() {
         String result = expressionResolver.resolve("#{something.advanced}");
         assertEquals("value123", result);
+    }
+
+    @Test
+    void shouldResolveNestedExpression() {
+        String result = expressionResolver.resolve("#{something.#{somethingKey}}");
+        assertEquals("value", result);
     }
 
     @Test

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -58,6 +58,7 @@ class DefaultExpressionResolverTest {
         Map<String, Object> rootMap = new HashMap<>();
         rootMap.put("something", nestedMap);
         rootMap.put("somethingKey", "deep");
+        rootMap.put("list", Arrays.asList("1", "#{something.special}"));
 
         return rootMap;
     }
@@ -157,7 +158,7 @@ class DefaultExpressionResolverTest {
     }
 
     @Test
-    void shouldGetKeysFor() {
+    void listValuesShouldGetKeysForPath() {
         Set<String> expected = new HashSet<>();
         expected.add("special");
         expected.add("deep");
@@ -166,7 +167,18 @@ class DefaultExpressionResolverTest {
         expected.add("special_nested");
         expected.add("frenchAddition");
 
-        Set<String> result = expressionResolver.getKeysFor("something");
+        Set<String> result = expressionResolver.listValues("something");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void listValuesShouldGetValuesForPathWithoutResolvingThem() {
+        Set<String> expected = new HashSet<>();
+        expected.add("1");
+        expected.add("#{something.special}");
+
+        Set<String> result = expressionResolver.listValues("list");
 
         assertEquals(expected, result);
     }

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -83,16 +83,30 @@ class DefaultExpressionResolverTest {
     }
 
     @Test
-    void shouldReturnEmptyStringWhenUnableToResolvePlaceholder() {
+    void shouldReturnEmptyStringWhenUnableToResolveSingleLocalePlaceholder() {
         LocalizedDummyDefinitions dummyDefinitions = mock(LocalizedDummyDefinitions.class);
         when(definitionProvider.get())
                 .thenReturn(singletonList(dummyDefinitions));
         when(dummyDefinitions.resolve(any()))
-                .thenReturn(null);
+                .thenReturn(emptyList());
         when(dummyDefinitions.getLocale())
                 .thenReturn("en");
         expressionResolver = new DefaultExpressionResolver(singletonList("en"), randomService, definitionProvider);
         String result = expressionResolver.resolve("#{something.notexisting}");
+        assertEquals("", result);
+    }
+
+    @Test
+    void shouldReturnEmptyStringWhenUnableToResolveMultiLocalePlaceholder() {
+        LocalizedDummyDefinitions dummyDefinitions = mock(LocalizedDummyDefinitions.class);
+        when(definitionProvider.get())
+                .thenReturn(singletonList(dummyDefinitions));
+        when(dummyDefinitions.resolve(any()))
+                .thenReturn(emptyList());
+        when(dummyDefinitions.getLocale())
+                .thenReturn("en");
+        expressionResolver = new DefaultExpressionResolver(singletonList("en"), randomService, definitionProvider);
+        String result = expressionResolver.resolve("#{{something.notexisting}}");
         assertEquals("", result);
     }
 

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -142,6 +142,14 @@ class DefaultExpressionResolverTest {
     }
 
     @Test
+    void shouldNotResolveEscapedHashSymbolWhenResolvingNestedExpression() {
+        lenient().when(randomService.nextInt(9))
+                .thenReturn(9);
+        String result = expressionResolver.resolve("\\##{something.#{somethingKey}}");
+        assertEquals("#value", result);
+    }
+
+    @Test
     void shouldResolveSpecialChars() {
         String result = expressionResolver.resolve("#{something.special}");
         assertEquals("$ $$ $ $$ \\abc", result);

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -17,6 +17,7 @@ import static java.util.Arrays.*;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -106,7 +107,7 @@ class DefaultExpressionResolverTest {
     }
 
     @Test
-    void shouldResolveKeyWithSecondaryLocaleIfNotFoundInPrimary() {
+    void shouldResolveValueWithSecondaryLocaleIfNotFoundInPrimary() {
         String result = expressionResolver.resolve("#{something.frenchAddition}");
         assertEquals("value", result);
     }
@@ -155,5 +156,14 @@ class DefaultExpressionResolverTest {
     void shouldResolveSpecialChars() {
         String result = expressionResolver.resolve("#{something.special}");
         assertEquals("$ $$ $ $$ \\abc", result);
+    }
+
+    @Test
+    void shouldResolveKeyFromEveryLocale() {
+        Set<String> result = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            result.add(expressionResolver.resolve("#{something}"));
+        }
+        assertTrue(result.contains("frenchAddition"));
     }
 }

--- a/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/DefaultExpressionResolverTest.java
@@ -156,30 +156,4 @@ class DefaultExpressionResolverTest {
         String result = expressionResolver.resolve("#{something.special}");
         assertEquals("$ $$ $ $$ \\abc", result);
     }
-
-    @Test
-    void listValuesShouldGetKeysForPath() {
-        Set<String> expected = new HashSet<>();
-        expected.add("special");
-        expected.add("deep");
-        expected.add("advanced");
-        expected.add("empty");
-        expected.add("special_nested");
-        expected.add("frenchAddition");
-
-        Set<String> result = expressionResolver.listValues("something");
-
-        assertEquals(expected, result);
-    }
-
-    @Test
-    void listValuesShouldGetValuesForPathWithoutResolvingThem() {
-        Set<String> expected = new HashSet<>();
-        expected.add("1");
-        expected.add("#{something.special}");
-
-        Set<String> result = expressionResolver.listValues("list");
-
-        assertEquals(expected, result);
-    }
 }

--- a/src/test/java/dev/codesoapbox/dummy4j/ResolvedValueTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/ResolvedValueTest.java
@@ -4,6 +4,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ResolvedValueTest {
 
@@ -16,6 +17,26 @@ class ResolvedValueTest {
 
         assertEquals(locale, result.getLocale());
         assertEquals(value, result.getValue());
+    }
+
+    @Test
+    void ofShouldThrowExceptionIfLocaleIsNull() {
+        String locale = null;
+        String value = "someValue";
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> ResolvedValue.of(locale, value));
+        assertEquals("Locale cannot be null", exception.getMessage());
+    }
+
+    @Test
+    void ofShouldThrowExceptionIfValueIsNull() {
+        String locale = "en";
+        String value = null;
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> ResolvedValue.of(locale, value));
+        assertEquals("Value cannot be null", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/dev/codesoapbox/dummy4j/ResolvedValueTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/ResolvedValueTest.java
@@ -1,0 +1,27 @@
+package dev.codesoapbox.dummy4j;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResolvedValueTest {
+
+    @Test
+    void ofShouldCreate() {
+        String locale = "en";
+        String value = "someValue";
+
+        ResolvedValue result = ResolvedValue.of(locale, value);
+
+        assertEquals(locale, result.getLocale());
+        assertEquals(value, result.getValue());
+    }
+
+    @Test
+    void equalsContract() {
+        EqualsVerifier.forClass(ResolvedValue.class)
+                .withNonnullFields("locale", "value")
+                .verify();
+    }
+}

--- a/src/test/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMapTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMapTest.java
@@ -101,4 +101,16 @@ class LocalizedDummyDefinitionsMapTest {
     void getKeysOfShouldReturnEmptySetWhenKeyIsNotFound() {
         assertEquals(emptyList(), dummyDefinitions.resolve("thisDoesntExist"));
     }
+
+    @Test
+    void shouldReturnNestedKeysWhenHigherKeyEndsWithDot() {
+        List<String> result = dummyDefinitions.resolve("something.");
+        assertEquals(Arrays.asList("evenDeeper", "deeper"), result);
+    }
+
+    @Test
+    void shouldReturnValueKeysWhenLastKeyEndsWithDot() {
+        List<String> result = dummyDefinitions.resolve("something.evenDeeper.thanThat.");
+        assertEquals(singletonList("actualValue"), result);
+    }
 }

--- a/src/test/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMapTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMapTest.java
@@ -89,25 +89,16 @@ class LocalizedDummyDefinitionsMapTest {
 
     @Test
     void shouldGetKeysFor() {
-        Set<String> expected = new HashSet<>();
-        expected.add("deeper");
-        expected.add("evenDeeper");
-
-        assertEquals(expected, dummyDefinitions.getKeysFor("something"));
+        assertEquals(Arrays.asList("evenDeeper", "deeper"), dummyDefinitions.resolve("something"));
     }
 
     @Test
     void shouldGetKeysForNested() {
-        assertEquals(singleton("thanThat"), dummyDefinitions.getKeysFor("something.evenDeeper"));
+        assertEquals(singletonList("thanThat"), dummyDefinitions.resolve("something.evenDeeper"));
     }
 
     @Test
     void getKeysOfShouldReturnEmptySetWhenKeyIsNotFound() {
-        assertEquals(emptySet(), dummyDefinitions.getKeysFor("thisDoesntExist"));
-    }
-
-    @Test
-    void getKeysOfShouldReturnEmptySetWhenKeyIsAValue() {
-        assertEquals(emptySet(), dummyDefinitions.getKeysFor("test_number"));
+        assertEquals(emptyList(), dummyDefinitions.resolve("thisDoesntExist"));
     }
 }

--- a/src/test/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMapTest.java
+++ b/src/test/java/dev/codesoapbox/dummy4j/definitions/LocalizedDummyDefinitionsMapTest.java
@@ -4,10 +4,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static java.util.Collections.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,6 +17,10 @@ class LocalizedDummyDefinitionsMapTest {
     void setUp() {
         final Map<String, Object> nestedMap = new HashMap<>();
         nestedMap.put("deeper", "actualValue");
+
+        final Map<String, Object> doublyNestedMap = new HashMap<>();
+        doublyNestedMap.put("thanThat", "actualValue");
+        nestedMap.put("evenDeeper", doublyNestedMap);
 
         final Map<String, Object> map = new HashMap<>();
         map.put("something", nestedMap);
@@ -84,5 +85,29 @@ class LocalizedDummyDefinitionsMapTest {
     void shouldResolveMixedList() {
         List<String> result = dummyDefinitions.resolve("test_mixed_list");
         assertEquals(Arrays.asList("1", "2"), result);
+    }
+
+    @Test
+    void shouldGetKeysFor() {
+        Set<String> expected = new HashSet<>();
+        expected.add("deeper");
+        expected.add("evenDeeper");
+
+        assertEquals(expected, dummyDefinitions.getKeysFor("something"));
+    }
+
+    @Test
+    void shouldGetKeysForNested() {
+        assertEquals(singleton("thanThat"), dummyDefinitions.getKeysFor("something.evenDeeper"));
+    }
+
+    @Test
+    void getKeysOfShouldReturnEmptySetWhenKeyIsNotFound() {
+        assertEquals(emptySet(), dummyDefinitions.getKeysFor("thisDoesntExist"));
+    }
+
+    @Test
+    void getKeysOfShouldReturnEmptySetWhenKeyIsAValue() {
+        assertEquals(emptySet(), dummyDefinitions.getKeysFor("test_number"));
     }
 }


### PR DESCRIPTION
* Change behavior of `LocalizedDummyDefinitions::resolve` to include resolving to lists of keys, update `ExpressionResolver` Javadoc accordingly
* Allow resolving nested placeholders with `ExpressionResolver::resolve` (`#{path.to.key1.#{path.to.key2}}`)
* Introduce multi-locale placeholders (`#{{path.to.key}}`)
* Document new features in Markdown and Javadoc
* Change some references of `key` to `path` in Javadoc
* Refactor `DefaultExpressionResolver`
* Add static import for Arrays in `DefaultExpressionResolverTest`
* Expand `LocalizedDummyDefinitionsMap` and `DefaultExpressionResolver` tests to check multi-locale resolving
* Fix bug with nested single-locale placeholders being resolved in a different locale than their parent expressions
* Fix bug where trying to resolve an unresolvable expression would sometimes result in an `ArrayIndexOutOfBoundsException`
* Make `LocalizedDummyDefinitionsMap` final
* Replace all mentions of a parser with 'expression resolver'
* Clarify removal of unresolvable placeholders from expressions
* Unify `path.to.key` / `key.path` / `key.path` references